### PR TITLE
Fix minor typo in README, on exporting token as env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Options:
 
 Once the token has been created, the recommended method is to set it via an environment variable `CSTREAM_TOKEN`:
 ```
-export CSTREAM_TOKEN xxxxxxxxxx
+export CSTREAM_TOKEN=xxxxxxxxxx
 ```
 Alternatively, the `--token` switch maybe used when invoking the program, e.g:
 ```


### PR DESCRIPTION
Minor typo in Readme. This might trip users and have them waste a second or two. We can avoid it ;) 